### PR TITLE
Relay flags to libv4l2rtspserver target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GSOAP_BIN?=$(GSOAP_PREFIX)/bin
 GSOAP_BASE=$(GSOAP_PREFIX)/share/gsoap
 GSOAP_PLUGINS=$(GSOAP_BASE)/plugin
 
+CMAKE_CXX_FLAGS:=$(CXXFLAGS)
 CXXFLAGS+=-std=c++11 -g2 -I inc -I ws-discovery/gsoap/
 CXXFLAGS+=-I gen -I $(GSOAP_PREFIX)/include -I $(GSOAP_PLUGINS) 
 CXXFLAGS+=-DWITH_DOM -DWITH_OPENSSL -DSOAP_PURE_VIRTUAL -fpermissive -pthread -DVERSION=\"$(VERSION)\"
@@ -64,7 +65,7 @@ libwsdd.a:
 # v4l2rtsp
 liblibv4l2rtspserver.a:
 	git submodule update --recursive --init v4l2rtspserver
-	cd v4l2rtspserver && cmake -DALSA=OFF . && make libv4l2rtspserver		
+	cd v4l2rtspserver && cmake -DALSA=OFF -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_FLAGS=$(CMAKE_CXX_FLAGS) . && make libv4l2rtspserver		
 	cp v4l2rtspserver/$@ .
 
 


### PR DESCRIPTION
## Description

libv4l2rtspserver is built without using the compile flags of the Makefile. 

## Related Issue

https://github.com/mpromonet/v4l2onvif/issues/12

## Motivation and Context

This change is needed to cross-compile libv4l2rtspserver using the liblibv4l2rtspserver.a target.
` CXXFLAGS=-I[include_dir] CXX=[c++-compiler] CC=[c_compiler] make liblibv4l2rtspserver.a`

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)